### PR TITLE
Fix: Address 'Readability library not found' error

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,4 @@
+// background.js
 // Listen for a message from the popup script.
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "extract_content") {
@@ -10,31 +11,52 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             }
             const tabId = tabs[0].id;
 
-            // Inject the Readability.js library, then the content script.
-            // This ensures Readability is available when content.js runs.
+            // Inject the Readability.js library first.
             chrome.scripting.executeScript({
                 target: { tabId: tabId },
                 files: ['Readability.js']
             }, () => {
+                if (chrome.runtime.lastError) {
+                    console.error("Error injecting Readability.js:", chrome.runtime.lastError);
+                    sendResponse({ error: "Failed to inject Readability.js: " + chrome.runtime.lastError.message });
+                    return;
+                }
+
+                // Now, inject the content extraction logic as a function.
                 chrome.scripting.executeScript({
                     target: { tabId: tabId },
-                    files: ['content.js']
+                    func: () => {
+                        // This IIFE will be stringified and executed on the page.
+                        // It's the same logic as content.js
+                        const documentClone = document.cloneNode(true);
+                        if (typeof Readability === 'undefined') {
+                            return { error: "Readability library not found (func injection context)." };
+                        }
+                        const reader = new Readability(documentClone);
+                        const article = reader.parse();
+                        if (article) {
+                            return {
+                                title: article.title,
+                                content: article.content,
+                                url: window.location.href
+                            };
+                        }
+                        return { error: "Could not find an article on this page (Readability parse failed in func)." };
+                    }
                 }, (injectionResults) => {
-                    // The result from the content script is in injectionResults.
-                    // Send it back to the popup.
                     if (chrome.runtime.lastError) {
-                        console.error(chrome.runtime.lastError);
-                        sendResponse({ error: chrome.runtime.lastError.message });
+                        console.error("Error injecting content extraction function:", chrome.runtime.lastError);
+                        sendResponse({ error: "Failed to inject content extraction function: " + chrome.runtime.lastError.message });
                     } else if (injectionResults && injectionResults[0] && injectionResults[0].result) {
                         sendResponse(injectionResults[0].result);
                     } else {
-                        sendResponse({ error: "Could not extract article." });
+                        // This case might occur if the injected function doesn't return a result,
+                        // or if injectionResults is structured unexpectedly.
+                        sendResponse({ error: "Could not extract article (no result from injected function)." });
                     }
                 });
             });
         });
-
-        // Return true to indicate that we will send a response asynchronously.
-        return true;
+        return true; // Indicates that we will send a response asynchronously.
     }
 });


### PR DESCRIPTION
This commit modifies how the content extraction script is injected to resolve an issue where `Readability.js` was not always available when `content.js` logic executed.

Changes:
- I updated `background.js` to first inject `Readability.js`.
- In the callback of the `Readability.js` injection, I've made it so the actual content extraction logic (previously in `content.js`) is now injected and executed as a function using `chrome.scripting.executeScript({ func: ... })`.
- This ensures that the content extraction code runs only after `Readability.js` has been loaded and processed by the browser, making the `Readability` object's availability more reliable.
- The `content.js` file is no longer directly injected by `background.js` for this operation but is kept for reference.