### PR TITLE
Fix extension injection issue

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,12 @@
   "background": {
     "service_worker": "background.js"
   },
+  "web_accessible_resources": [
+    {
+      "resources": ["Readability.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",


### PR DESCRIPTION
## Summary
- add `web_accessible_resources` entry so Readability.js can be injected

## Testing
- `node --check background.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68468d65eea48326b3c76e97800f56b5